### PR TITLE
fix(WikiSelfRolesCommand): Limit self-assignable roles

### DIFF
--- a/src/commands/confe/WikiSelfRolesCommand.ts
+++ b/src/commands/confe/WikiSelfRolesCommand.ts
@@ -18,14 +18,17 @@ export class WikiSelfRolesCommand extends Command {
     const { client } = this.container;
     const guildRoles = message.guild.roles.cache;
     const wikiIndexRole = message.guild.roles.resolve(env.WIKI_ROLE_GROUP) as Role;
+    const countryIndexRole = message.guild.roles.resolve(env.COUNTRY_ROLE_GROUP) as Role;
+    const assignableRoles: Role[] = Array.from(guildRoles.values())
+      .filter((r) => r.editable && r.position < wikiIndexRole.position && r.position > countryIndexRole.position)
+      .sort((a, b) => b.position - a.position);
+
     const wikiNamesResolver = Args.make((arg) => Args.ok(arg.split(',').map((arg) => arg.trim())));
     const wikiNames = await args.restResult(wikiNamesResolver);
 
     if (wikiNames.success) {
       const assignedRoles: Role[] = [];
-      guildRoles.each((role) => {
-        if (role.position >= wikiIndexRole.position) return;
-        if (role.position === 0) return; // @everyone role
+      assignableRoles.forEach((role) => {
         wikiNames.value.forEach((wikiName: string) => {
           if (!wikiName) return;
           const similarityScore = stringSimilarity(wikiName, role.name);
@@ -46,16 +49,7 @@ export class WikiSelfRolesCommand extends Command {
           .reply('⚠️ No encontré ningún rol de wiki similar a lo que has escrito. Revisa e intenta nuevamente.')
           .catch(client.logException);
     } else {
-      const assignableRoles: Role[] = [];
       const rolesPerPage = 20;
-      guildRoles
-        .filter((r) => r.editable && r.position < wikiIndexRole.position)
-        .sort((a, b) => b.position - a.position)
-        .each((role) => {
-          if (role.position >= wikiIndexRole.position) return;
-          if (role.position === 0) return; // @everyone role
-          assignableRoles.push(role);
-        });
 
       const assignableRolesPages: Role[][] = new Array(Math.ceil(assignableRoles.length / rolesPerPage))
         .fill(null)

--- a/src/lib/ConfeBot.ts
+++ b/src/lib/ConfeBot.ts
@@ -23,7 +23,7 @@ class ConfeBot extends SapphireClient {
     if (Object.keys(context).length) this.logger.error(err, '\nContext:', context);
     else this.logger.error(err);
 
-    if (env.HONEYBADGER_API_KEY) {
+    if (env?.HONEYBADGER_API_KEY) {
       Honeybadger.resetContext(context);
       Honeybadger.notify(err);
     }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -17,6 +17,7 @@ export const schema = {
   },
   MW_API: String,
 
+  // TODO: these should be stored in the database instead
   GUILD_ID: String,
   GUILD_INVITE: String,
 
@@ -31,7 +32,8 @@ export const schema = {
   FDUSER_ROLE: String,
   STAFF_ROLE: String,
   SEGURIDAD_ROLE: String,
-  WIKI_ROLE_GROUP: String
+  WIKI_ROLE_GROUP: String,
+  COUNTRY_ROLE_GROUP: String
 };
 
 export let env: Env;


### PR DESCRIPTION
Con la nueva actualización de **TAXCY**, es posible asignarse roles de países mediante el comando `c!wikis`. Este PR corrige dicho comportamiento, agregando un rol que agrupe los países y limitando los roles autoasignables a los roles entre ambos grupos (wikis y países).

### Notas
* [Conversación relacionada](https://canary.discord.com/channels/247524732411445248/879399533069619301/902507557871054889).
* ❗️Se agrega variable de entorno `COUNTRY_ROLE_GROUP`.